### PR TITLE
게시글 댓글 페이징 조회 API 개발하기

### DIFF
--- a/src/main/java/com/leesh/devlab/constant/dto/PostCommentDto.java
+++ b/src/main/java/com/leesh/devlab/constant/dto/PostCommentDto.java
@@ -1,0 +1,23 @@
+package com.leesh.devlab.constant.dto;
+
+import com.leesh.devlab.domain.comment.Comment;
+import com.querydsl.core.annotations.QueryProjection;
+
+public record PostCommentDto(Long id, String contents, String author, long likeCount, Long createdAt, Long modifiedAt) {
+
+    @QueryProjection
+    public PostCommentDto {
+    }
+
+    public static PostCommentDto from(Comment comment) {
+        return new PostCommentDto(
+                comment.getId(),
+                comment.getContents(),
+                comment.getMember().getNickname(),
+                comment.getLikes().size(),
+                comment.getCreatedAt(),
+                comment.getModifiedAt()
+        );
+    }
+
+}

--- a/src/main/java/com/leesh/devlab/constant/dto/PostDto.java
+++ b/src/main/java/com/leesh/devlab/constant/dto/PostDto.java
@@ -7,9 +7,8 @@ import lombok.Builder;
 import java.util.List;
 
 @Builder
-public record PostDetailDto(
+public record PostDto(
         Long id, String title, String contents, Category category, String author,
-        @JsonProperty("comment_details") List<CommentDetailDto> commentDetailDtos,
         List<String> tags,
         int likeCount,
         Long createdAt, Long modifiedAt) {

--- a/src/main/java/com/leesh/devlab/controller/MemberController.java
+++ b/src/main/java/com/leesh/devlab/controller/MemberController.java
@@ -71,7 +71,7 @@ public class MemberController {
     @GetMapping(value = "/{id}/posts", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<Page<PostInfoDto>> getMemberPosts(@PathVariable("id") Long memberId, @PageableDefault(size = 20) Pageable pageable) {
 
-        Page<PostInfoDto> postPage = postService.getLists(pageable, memberId);
+        Page<PostInfoDto> postPage = postService.getPosts(pageable, memberId);
 
         return ResponseEntity.ok(postPage);
     }

--- a/src/main/java/com/leesh/devlab/controller/PostController.java
+++ b/src/main/java/com/leesh/devlab/controller/PostController.java
@@ -1,8 +1,8 @@
 package com.leesh.devlab.controller;
 
 import com.leesh.devlab.config.LoginMemberAnno;
-import com.leesh.devlab.constant.dto.*;
 import com.leesh.devlab.constant.Category;
+import com.leesh.devlab.constant.dto.*;
 import com.leesh.devlab.service.CommentService;
 import com.leesh.devlab.service.LikeService;
 import com.leesh.devlab.service.PostService;
@@ -28,6 +28,14 @@ public class PostController {
     public ResponseEntity<PostDetailDto> getDetail(@PathVariable("post-id") Long postId) {
 
         PostDetailDto responseDto = postService.getDetail(postId);
+
+        return ResponseEntity.ok(responseDto);
+    }
+
+    @GetMapping(value = "/{post-id}/comments", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<?> getPostComments(@PathVariable("post-id") Long postId, Pageable pageable) {
+
+        var responseDto = commentService.getPostComments(pageable, postId);
 
         return ResponseEntity.ok(responseDto);
     }

--- a/src/main/java/com/leesh/devlab/controller/PostController.java
+++ b/src/main/java/com/leesh/devlab/controller/PostController.java
@@ -25,9 +25,9 @@ public class PostController {
     private final LikeService likeService;
 
     @GetMapping(value = "/{post-id}", produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<PostDetailDto> getDetail(@PathVariable("post-id") Long postId) {
+    public ResponseEntity<PostDto> getPost(@PathVariable("post-id") Long postId) {
 
-        PostDetailDto responseDto = postService.getDetail(postId);
+        PostDto responseDto = postService.getPost(postId);
 
         return ResponseEntity.ok(responseDto);
     }
@@ -41,10 +41,10 @@ public class PostController {
     }
 
     @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<Page<PostInfoDto>> getLists(@RequestParam(value = "category", required = false) Category category, @PageableDefault(size = 20) Pageable pageable,
+    public ResponseEntity<Page<PostInfoDto>> getPosts(@RequestParam(value = "category", required = false) Category category, @PageableDefault(size = 20) Pageable pageable,
                                                       @RequestParam(value = "keyword", required = false) String keyword) {
 
-        var responseDto = postService.getLists(category, pageable, keyword);
+        var responseDto = postService.getPosts(category, pageable, keyword);
 
         return ResponseEntity.ok(responseDto);
     }

--- a/src/main/java/com/leesh/devlab/domain/comment/Comment.java
+++ b/src/main/java/com/leesh/devlab/domain/comment/Comment.java
@@ -1,17 +1,18 @@
 package com.leesh.devlab.domain.comment;
 
+import com.leesh.devlab.constant.ErrorCode;
+import com.leesh.devlab.constant.dto.LoginMemberDto;
 import com.leesh.devlab.domain.BaseEntity;
 import com.leesh.devlab.domain.like.Like;
 import com.leesh.devlab.domain.member.Member;
 import com.leesh.devlab.domain.post.Post;
-import com.leesh.devlab.constant.ErrorCode;
 import com.leesh.devlab.exception.custom.BusinessException;
-import com.leesh.devlab.constant.dto.LoginMemberDto;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/com/leesh/devlab/domain/comment/CommentRepository.java
+++ b/src/main/java/com/leesh/devlab/domain/comment/CommentRepository.java
@@ -1,5 +1,6 @@
 package com.leesh.devlab.domain.comment;
 
+import com.leesh.devlab.constant.dto.PostCommentDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/src/main/java/com/leesh/devlab/domain/comment/CommentRepositoryCustom.java
+++ b/src/main/java/com/leesh/devlab/domain/comment/CommentRepositoryCustom.java
@@ -1,11 +1,16 @@
 package com.leesh.devlab.domain.comment;
 
 import com.leesh.devlab.constant.dto.CommentDto;
+import com.leesh.devlab.constant.dto.PostCommentDto;
+import com.leesh.devlab.domain.post.Post;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.Query;
 
 public interface CommentRepositoryCustom {
 
     Page<CommentDto> getCommentPage(Pageable pageable, Long memberId);
+
+    Page<PostCommentDto> getPostComments(Pageable pageable, Long postId);
 
 }

--- a/src/main/java/com/leesh/devlab/domain/comment/CommentRepositoryImpl.java
+++ b/src/main/java/com/leesh/devlab/domain/comment/CommentRepositoryImpl.java
@@ -1,11 +1,11 @@
 package com.leesh.devlab.domain.comment;
 
-import com.leesh.devlab.constant.dto.CommentDto;
-import com.leesh.devlab.constant.dto.QCommentDto;
-import com.leesh.devlab.constant.dto.QCommentDto_PostDto;
+import com.leesh.devlab.constant.dto.*;
+import com.querydsl.core.types.Expression;
 import com.querydsl.core.types.ExpressionUtils;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
@@ -21,6 +21,7 @@ import java.util.List;
 import static com.leesh.devlab.domain.comment.QComment.comment;
 import static com.leesh.devlab.domain.like.QLike.like;
 import static com.leesh.devlab.domain.member.QMember.member;
+import static com.leesh.devlab.domain.post.QPost.post;
 import static com.querydsl.core.types.ExpressionUtils.count;
 
 @RequiredArgsConstructor
@@ -32,20 +33,15 @@ public class CommentRepositoryImpl implements CommentRepositoryCustom {
     @Override
     public Page<CommentDto> getCommentPage(Pageable pageable, Long memberId) {
 
-        List<CommentDto> commentDtos = queryFactory.select(new QCommentDto(
+        List<CommentDto> content = queryFactory.select(new QCommentDto(
                         comment.id, comment.contents, member.nickname,
-                        ExpressionUtils.as(
-                                JPAExpressions
-                                        .select(count(like.id))
-                                        .from(like)
-                                        .where(like.comment.eq(comment)),
-                                "likeCount"),
+                        getCommentLikeCount(),
                         comment.createdAt, comment.modifiedAt,
                         new QCommentDto_PostDto(comment.post.id, comment.post.title, comment.post.category)))
                 .from(comment)
                 .innerJoin(comment.member, member)
                 .leftJoin(comment.post)
-                .where(comment.member.id.eq(memberId))
+                .where(memberIdEq(memberId))
                 .orderBy(getOrderBy(pageable.getSort()))
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
@@ -53,10 +49,49 @@ public class CommentRepositoryImpl implements CommentRepositoryCustom {
 
         long totalCount = queryFactory
                 .selectFrom(comment)
-                .where(comment.member.id.eq(memberId))
+                .where(memberIdEq(memberId))
                 .fetch().size();
 
-        return new PageImpl<>(commentDtos, pageable, totalCount);
+        return new PageImpl<>(content, pageable, totalCount);
+    }
+
+    private static Expression<Long> getCommentLikeCount() {
+        return ExpressionUtils.as(
+                JPAExpressions
+                        .select(count(like.id))
+                        .from(like)
+                        .where(like.comment.eq(comment)),
+                "likeCount");
+    }
+
+    private static BooleanExpression memberIdEq(Long memberId) {
+        return comment.member.id.eq(memberId);
+    }
+
+    @Override
+    public Page<PostCommentDto> getPostComments(Pageable pageable, Long postId) {
+
+        List<PostCommentDto> content = queryFactory
+                .select(new QPostCommentDto(comment.id, comment.contents, member.nickname, getCommentLikeCount(), comment.createdAt, comment.modifiedAt))
+                .from(comment)
+                .innerJoin(comment.member, member)
+                .leftJoin(comment.post, post)
+                .where(postIdEq(postId))
+                .orderBy(getOrderBy(pageable.getSort()))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        long totalCount = queryFactory
+                .selectFrom(comment)
+                .where(postIdEq(postId))
+                .fetch().size();
+
+        return new PageImpl<>(content, pageable, totalCount);
+    }
+
+    private static BooleanExpression postIdEq(Long postId) {
+        return comment.post.id.eq(postId);
     }
 
     private OrderSpecifier<?>[] getOrderBy(Sort sort) {

--- a/src/main/java/com/leesh/devlab/domain/post/PostRepositoryCustom.java
+++ b/src/main/java/com/leesh/devlab/domain/post/PostRepositoryCustom.java
@@ -7,6 +7,6 @@ import org.springframework.data.domain.Pageable;
 
 public interface PostRepositoryCustom {
 
-    Page<PostInfoDto>  getPostPage(Category category, Pageable pageable, String keyword, Long memberId);
+    Page<PostInfoDto> getPosts(Category category, Pageable pageable, String keyword, Long memberId);
 
 }

--- a/src/main/java/com/leesh/devlab/service/CommentService.java
+++ b/src/main/java/com/leesh/devlab/service/CommentService.java
@@ -1,18 +1,14 @@
 package com.leesh.devlab.service;
 
+import com.leesh.devlab.constant.ErrorCode;
+import com.leesh.devlab.constant.dto.*;
 import com.leesh.devlab.domain.comment.Comment;
 import com.leesh.devlab.domain.comment.CommentRepository;
 import com.leesh.devlab.domain.member.Member;
 import com.leesh.devlab.domain.member.MemberRepository;
 import com.leesh.devlab.domain.post.Post;
 import com.leesh.devlab.domain.post.PostRepository;
-import com.leesh.devlab.constant.dto.CommentDetailDto;
-import com.leesh.devlab.constant.dto.CommentDto;
-import com.leesh.devlab.constant.dto.CreateCommentRequestDto;
-import com.leesh.devlab.constant.dto.CreateCommentResponseDto;
-import com.leesh.devlab.constant.ErrorCode;
 import com.leesh.devlab.exception.custom.BusinessException;
-import com.leesh.devlab.constant.dto.LoginMemberDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -111,10 +107,12 @@ public class CommentService {
 
     public Page<CommentDto> getLists(Pageable pageable, Long memberId) {
 
-        Page<CommentDto> comments = commentRepository.getCommentPage(pageable, memberId);
+        return commentRepository.getCommentPage(pageable, memberId);
+    }
 
-        return comments;
+    public Page<PostCommentDto> getPostComments(Pageable pageable, Long postId) {
 
+        return commentRepository.getPostComments(pageable, postId);
     }
 
     public Page<CommentDetailDto> getListsByMemberId(Long memberId, Pageable pageable) {

--- a/src/test/java/com/leesh/devlab/controller/MemberControllerTest.java
+++ b/src/test/java/com/leesh/devlab/controller/MemberControllerTest.java
@@ -285,7 +285,7 @@ public class MemberControllerTest {
         postInfoDtos.add(postInfoDto);
         Page<PostInfoDto> postPage = new PageImpl<>(postInfoDtos, pageable, postInfoDtos.size());
 
-        given(postService.getLists(pageable, testMember.id()))
+        given(postService.getPosts(pageable, testMember.id()))
                 .willReturn(postPage);
 
         // when
@@ -328,7 +328,7 @@ public class MemberControllerTest {
                 .andExpect(jsonPath("$.sort").isMap())
                 .andDo(print());
 
-        then(postService).should().getLists(pageable, testMember.id());
+        then(postService).should().getPosts(pageable, testMember.id());
 
         // API Docs
         result.andDo(document("get-member-posts",

--- a/src/test/java/com/leesh/devlab/controller/PostControllerTest.java
+++ b/src/test/java/com/leesh/devlab/controller/PostControllerTest.java
@@ -1,12 +1,12 @@
 package com.leesh.devlab.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.leesh.devlab.constant.dto.*;
-import com.leesh.devlab.constant.Role;
 import com.leesh.devlab.constant.Category;
+import com.leesh.devlab.constant.Role;
+import com.leesh.devlab.constant.TokenType;
+import com.leesh.devlab.constant.dto.*;
 import com.leesh.devlab.jwt.Token;
 import com.leesh.devlab.jwt.TokenService;
-import com.leesh.devlab.constant.TokenType;
 import com.leesh.devlab.jwt.implementation.Jwt;
 import com.leesh.devlab.service.CommentService;
 import com.leesh.devlab.service.LikeService;
@@ -106,12 +106,10 @@ class PostControllerTest {
         long commentModifiedAt = System.currentTimeMillis();
         int commentLikeCount = 10;
 
-        List<CommentDetailDto> commentDetailDtos = new ArrayList<>();
-        commentDetailDtos.add(new CommentDetailDto(commentId, commentContent, commentAuthor, commentCreatedAt, commentModifiedAt, postId, commentLikeCount));
-        PostDetailDto postDetailDto = new PostDetailDto(postId, title, content, category, author, commentDetailDtos, tags, postLikeCount, createdAt, createdAt);
+        PostDto postDto = new PostDto(postId, title, content, category, author, tags, postLikeCount, createdAt, createdAt);
 
-        given(postService.getDetail(postId))
-                .willReturn(postDetailDto);
+        given(postService.getPost(postId))
+                .willReturn(postDto);
 
         // when
         var result = mvc.perform(get("/api/posts/{post-id}", postId)
@@ -125,13 +123,6 @@ class PostControllerTest {
                 .andExpect(jsonPath("$.contents").value(content))
                 .andExpect(jsonPath("$.category").value(category.name()))
                 .andExpect(jsonPath("$.author").value(author))
-                .andExpect(jsonPath("$.comment_details[0].id").value(commentId))
-                .andExpect(jsonPath("$.comment_details[0].contents").value(commentContent))
-                .andExpect(jsonPath("$.comment_details[0].author").value(commentAuthor))
-                .andExpect(jsonPath("$.comment_details[0].created_at").value(commentCreatedAt))
-                .andExpect(jsonPath("$.comment_details[0].modified_at").value(commentModifiedAt))
-                .andExpect(jsonPath("$.comment_details[0].like_count").value(commentLikeCount))
-                .andExpect(jsonPath("$.comment_details[0].post_id").value(postId))
                 .andExpect(jsonPath("$.tags[0]").value(tags.get(0)))
                 .andExpect(jsonPath("$.tags[1]").value(tags.get(1)))
                 .andExpect(jsonPath("$.like_count").value(postLikeCount))
@@ -139,7 +130,7 @@ class PostControllerTest {
                 .andExpect(jsonPath("$.modified_at").value(createdAt))
                 .andDo(print());
 
-        then(postService).should().getDetail(1L);
+        then(postService).should().getPost(1L);
 
         // API Docs
         result.andDo(document("posts/get-detail",
@@ -152,14 +143,6 @@ class PostControllerTest {
                         fieldWithPath("contents").description("내용"),
                         fieldWithPath("category").description("카테고리"),
                         fieldWithPath("author").description("작성자"),
-                        fieldWithPath("comment_details").description("댓글 목록"),
-                        fieldWithPath("comment_details[].id").description("식별자"),
-                        fieldWithPath("comment_details[].contents").description("내용"),
-                        fieldWithPath("comment_details[].author").description("작성자"),
-                        fieldWithPath("comment_details[].created_at").description("생성일"),
-                        fieldWithPath("comment_details[].modified_at").description("수정일"),
-                        fieldWithPath("comment_details[].like_count").description("좋아요 수"),
-                        fieldWithPath("comment_details[].post_id").description("게시글 식별자"),
                         fieldWithPath("tags").description("태그 목록"),
                         fieldWithPath("like_count").description("좋아요 수"),
                         fieldWithPath("created_at").description("생성일"),
@@ -194,7 +177,7 @@ class PostControllerTest {
 
         Pageable pageable = PageRequest.of(pageNumber, pageSize, sort);
         Page<PostInfoDto> postPages = PageableExecutionUtils.getPage(postInfoDtos, pageable, postInfoDtos::size);
-        given(postService.getLists(any(Category.class), any(Pageable.class), any(String.class)))
+        given(postService.getPosts(any(Category.class), any(Pageable.class), any(String.class)))
                 .willReturn(postPages);
 
         // when
@@ -236,7 +219,7 @@ class PostControllerTest {
                 .andExpect(jsonPath("$.sort").isMap())
                 .andDo(print());
 
-        then(postService).should().getLists(any(Category.class), any(Pageable.class), any(String.class));
+        then(postService).should().getPosts(any(Category.class), any(Pageable.class), any(String.class));
 
         // API Docs
         result.andDo(document("posts/get-lists",


### PR DESCRIPTION
기존 게시글 세부 조회 API에서 댓글 데이터를 함께 가져오던 방식에서 게시글 ID로 댓글을 조회하는 방식으로 변경하였습니다.
