### PR TITLE
조회 수 기능 개발하기

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ create table posts
     title       varchar(255) not null,
     contents    text         not null,
     category    varchar(20)  not null,
+    views       bigint       not null default 0,
     created_by  varchar(255) not null,
     modified_by varchar(255) not null,
     created_at  bigint       not null,
@@ -120,7 +121,6 @@ create table comments
 
 create index comments_member_id_idx on comments (member_id);
 create index comments_post_id_idx on comments (post_id);
-create fulltext index comments_contents_idx on comments (contents);
 create index comments_created_at_idx on comments (created_at);
 
 create table likes
@@ -153,7 +153,7 @@ create table tags
     primary key (id)
 ) default character set utf8mb4 collate utf8mb4_general_ci;
 
-create fulltext index tags_name_idx on tags (name);
+create fulltext index tags_name_idx on tags (name) with parser ngram;
 
 create table hashtags
 (

--- a/src/main/java/com/leesh/devlab/constant/dto/PostDto.java
+++ b/src/main/java/com/leesh/devlab/constant/dto/PostDto.java
@@ -11,13 +11,13 @@ import java.util.List;
 public record PostDto(
         Long id, String title, String contents, Category category, AuthorDto author,
         List<String> tags,
-        long likeCount, long commentCount,
+        long likeCount, long commentCount, long viewCount,
         Long createdAt, Long modifiedAt) {
 
     @QueryProjection
-    public PostDto(Long id, String title, String contents, Category category, AuthorDto author, String tags, long likeCount, long commentCount, Long createdAt, Long modifiedAt) {
+    public PostDto(Long id, String title, String contents, Category category, AuthorDto author, String tags, long likeCount, long commentCount, long viewCount, Long createdAt, Long modifiedAt) {
         this(id, title, contents, category, author,
                 tags != null ? Arrays.stream(tags.split(",")).toList() : List.of(),
-                likeCount, commentCount, createdAt, modifiedAt);
+                likeCount, commentCount, viewCount, createdAt, modifiedAt);
     }
 }

--- a/src/main/java/com/leesh/devlab/domain/post/Post.java
+++ b/src/main/java/com/leesh/devlab/domain/post/Post.java
@@ -1,13 +1,13 @@
 package com.leesh.devlab.domain.post;
 
 import com.leesh.devlab.constant.Category;
+import com.leesh.devlab.constant.ErrorCode;
 import com.leesh.devlab.domain.BaseEntity;
 import com.leesh.devlab.domain.comment.Comment;
 import com.leesh.devlab.domain.hashtag.Hashtag;
 import com.leesh.devlab.domain.like.Like;
 import com.leesh.devlab.domain.member.Member;
 import com.leesh.devlab.domain.tag.Tag;
-import com.leesh.devlab.constant.ErrorCode;
 import com.leesh.devlab.exception.custom.BusinessException;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -42,6 +42,9 @@ public class Post extends BaseEntity {
     @Enumerated(EnumType.STRING)
     @Column(name = "category", length = 10, nullable = false)
     private Category category;
+
+    @Column(name = "views", nullable = false)
+    private Long views = 0L;
 
     @JoinColumn(name = "member_id", nullable = false)
     @ManyToOne(optional = false, fetch = FetchType.LAZY)
@@ -127,4 +130,7 @@ public class Post extends BaseEntity {
 
     }
 
+    public void increaseViews() {
+        this.views++;
+    }
 }

--- a/src/main/java/com/leesh/devlab/domain/post/PostRepositoryImpl.java
+++ b/src/main/java/com/leesh/devlab/domain/post/PostRepositoryImpl.java
@@ -76,6 +76,7 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
                                                 .from(comment)
                                                 .where(comment.post.eq(post)),
                                         "commentCount"),
+                                post.views,
                                 post.createdAt,
                                 post.modifiedAt
                         )
@@ -139,6 +140,7 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
                 case "like_count" -> orders.add(new OrderSpecifier<>(direction, post.likes.size()));
                 case "created_at" -> orders.add(new OrderSpecifier<>(direction, post.createdAt));
                 case "modified_at" -> orders.add(new OrderSpecifier<>(direction, post.modifiedAt));
+                case "view_count" -> orders.add(new OrderSpecifier<>(direction, post.views));
                 default -> {}
             }
         }

--- a/src/main/java/com/leesh/devlab/service/PostService.java
+++ b/src/main/java/com/leesh/devlab/service/PostService.java
@@ -101,15 +101,17 @@ public class PostService {
         }
     }
 
-    @Transactional(readOnly = true)
+    @Transactional
     public PostDto getPost(Long postId) {
 
         Post post = getPostByIdWithMemberAndLikes(postId);
+        // 게시글의 조회수를 증가시킨다. TODO 추후 캐시 방식으로 변경하기
+        post.increaseViews();
 
-        return generatePostDetail(post);
+        return generatePostDto(post);
     }
 
-    private PostDto generatePostDetail(Post post) {
+    private PostDto generatePostDto(Post post) {
 
         List<String> tags = post.getHashtags().stream()
                 .map(Hashtag::getTag)
@@ -126,6 +128,7 @@ public class PostService {
                 .author(new AuthorDto(post.getMember().getId(), post.getMember().getNickname()))
                 .tags(tags)
                 .likeCount(likeCount)
+                .viewCount(post.getViews())
                 .createdAt(post.getCreatedAt())
                 .modifiedAt(post.getModifiedAt())
                 .build();
@@ -148,6 +151,6 @@ public class PostService {
 
         Page<Post> page = postRepository.findAllWithMemberByMemberId(memberId, pageable);
 
-        return page.map(this::generatePostDetail);
+        return page.map(this::generatePostDto);
     }
 }

--- a/src/test/java/com/leesh/devlab/controller/MemberControllerTest.java
+++ b/src/test/java/com/leesh/devlab/controller/MemberControllerTest.java
@@ -272,6 +272,7 @@ public class MemberControllerTest {
         Category category = Category.INFORMATION;
         List<String> tags = List.of("java", "spring");
         long likeCount = 11;
+        long viewCount = 1092;
         long createdAt = System.currentTimeMillis();
         long modifiedAt = System.currentTimeMillis();
         long commentCount = 10;
@@ -281,7 +282,7 @@ public class MemberControllerTest {
         Pageable pageable = PageRequest.of(pageNumber, pageSize, sort);
 
         AuthorDto author = new AuthorDto(testMember.id(), testMember.nickname());
-        PostDto postDto = new PostDto(postId, title, content, category, author, tags, likeCount, commentCount, createdAt, modifiedAt);
+        PostDto postDto = new PostDto(postId, title, content, category, author, tags, likeCount, commentCount, viewCount, createdAt, modifiedAt);
         List<PostDto> postDtos = new ArrayList<>();
         postDtos.add(postDto);
         Page<PostDto> postPage = new PageImpl<>(postDtos, pageable, postDtos.size());
@@ -307,6 +308,7 @@ public class MemberControllerTest {
                 .andExpect(jsonPath("$.content[0].author.nickname").value(author.nickname()))
                 .andExpect(jsonPath("$.content[0].like_count").value(likeCount))
                 .andExpect(jsonPath("$.content[0].comment_count").value(commentCount))
+                .andExpect(jsonPath("$.content[0].view_count").value(viewCount))
                 .andExpect(jsonPath("$.content[0].tags").exists())
                 .andExpect(jsonPath("$.content[0].tags[0]").value(tags.get(0)))
                 .andExpect(jsonPath("$.content[0].tags[1]").value(tags.get(1)))
@@ -356,6 +358,7 @@ public class MemberControllerTest {
                         fieldWithPath("content[].author.nickname").description("작성자 닉네임"),
                         fieldWithPath("content[].like_count").description("좋아요 수"),
                         fieldWithPath("content[].comment_count").description("댓글 수"),
+                        fieldWithPath("content[].view_count").description("조회 수"),
                         fieldWithPath("content[].tags").description("태그 목록"),
                         fieldWithPath("pageable").description("페이지 정보"),
                         fieldWithPath("pageable.offset").description("페이지 오프셋"),

--- a/src/test/java/com/leesh/devlab/controller/PostControllerTest.java
+++ b/src/test/java/com/leesh/devlab/controller/PostControllerTest.java
@@ -98,9 +98,10 @@ class PostControllerTest {
         List<String> tags = List.of("java", "spring");
         int postLikeCount = 11;
         int commentCount = 10;
+        int viewCount = 1021;
         long createdAt = System.currentTimeMillis();
 
-        PostDto postDto = new PostDto(postId, title, content, category, author, tags, postLikeCount, commentCount, createdAt, createdAt);
+        PostDto postDto = new PostDto(postId, title, content, category, author, tags, postLikeCount, commentCount, viewCount, createdAt, createdAt);
 
         given(postService.getPost(postId))
                 .willReturn(postDto);
@@ -123,6 +124,7 @@ class PostControllerTest {
                 .andExpect(jsonPath("$.tags[1]").value(tags.get(1)))
                 .andExpect(jsonPath("$.like_count").value(postLikeCount))
                 .andExpect(jsonPath("$.comment_count").value(commentCount))
+                .andExpect(jsonPath("$.view_count").value(viewCount))
                 .andExpect(jsonPath("$.created_at").value(createdAt))
                 .andExpect(jsonPath("$.modified_at").value(createdAt))
                 .andDo(print());
@@ -145,6 +147,7 @@ class PostControllerTest {
                         fieldWithPath("tags").description("태그 목록"),
                         fieldWithPath("like_count").description("좋아요 수"),
                         fieldWithPath("comment_count").description("댓글 수"),
+                        fieldWithPath("view_count").description("조회 수"),
                         fieldWithPath("created_at").description("생성일"),
                         fieldWithPath("modified_at").description("수정일")
                 )));
@@ -161,11 +164,12 @@ class PostControllerTest {
         long createdAt = System.currentTimeMillis();
         long commentCount = 10;
         long likeCount = 10;
+        long viewCount = 1022;
         List<String> tags = List.of("spring", "java");
 
         AuthorDto author = new AuthorDto(10L, "개발맨");
 
-        PostDto postDto = new PostDto(postId, title, contents, category, author, tags, likeCount, commentCount, createdAt, createdAt);
+        PostDto postDto = new PostDto(postId, title, contents, category, author, tags, likeCount, commentCount, viewCount, createdAt, createdAt);
         List<PostDto> content = new ArrayList<>();
         content.add(postDto);
 
@@ -199,6 +203,7 @@ class PostControllerTest {
                 .andExpect(jsonPath("$.content[0].tags[1]").value(tags.get(1)))
                 .andExpect(jsonPath("$.content[0].like_count").value(likeCount))
                 .andExpect(jsonPath("$.content[0].comment_count").value(commentCount))
+                .andExpect(jsonPath("$.content[0].view_count").value(viewCount))
                 .andExpect(jsonPath("$.content[0].created_at").value(createdAt))
                 .andExpect(jsonPath("$.content[0].modified_at").value(createdAt))
                 .andExpect(jsonPath("$.pageable.offset").value(posts.getPageable().getOffset()))
@@ -245,6 +250,7 @@ class PostControllerTest {
                         fieldWithPath("content[].tags").description("태그 목록"),
                         fieldWithPath("content[].like_count").description("좋아요 수"),
                         fieldWithPath("content[].comment_count").description("댓글 수"),
+                        fieldWithPath("content[].view_count").description("조회 수"),
                         fieldWithPath("content[].created_at").description("생성일"),
                         fieldWithPath("content[].modified_at").description("수정일"),
                         fieldWithPath("pageable").description("페이지 정보"),


### PR DESCRIPTION
현재는 제품 출시를 위해 게시글 API 호출 시 조회 수를 증가시키는 방식으로 개발하였지만, 추후 서비스가 안정화 되면 캐시방식으로 변경하여야 합니다.